### PR TITLE
Set up Swagger for http URL

### DIFF
--- a/ProductsMicroservice.API/Properties/launchSettings.json
+++ b/ProductsMicroservice.API/Properties/launchSettings.json
@@ -7,7 +7,8 @@
         "ASPNETCORE_ENVIRONMENT": "Development"
       },
       "dotnetRunMessages": true,
-      "applicationUrl": "http://localhost:5114"
+      "applicationUrl": "http://localhost:5114",
+      "launchUrl": "swagger"
     },
     "https": {
       "commandName": "Project",


### PR DESCRIPTION
Adding **swagger** at the end of http URL by default 
i.e. from **http://localhost:5114/** to **http://localhost:5114/swagger**